### PR TITLE
Bump HC version

### DIFF
--- a/src/FluentChoco.csproj
+++ b/src/FluentChoco.csproj
@@ -18,7 +18,7 @@
 		<RepositoryUrl>https://github.com/dalrankov/FluentChoco</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/dalrankov/FluentChoco</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>
-		<Version>2.0.0</Version>
+		<Version>2.0.1</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
@@ -34,7 +34,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation" Version="9.3.0" />
-		<PackageReference Include="HotChocolate.Execution" Version="11.0.7" />
+		<PackageReference Include="HotChocolate.Execution" Version="11.0.9" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
FluentChoco is not working with 11.0.9+

Related to:
- https://github.com/appany/AppAny.HotChocolate.FluentValidation/tree/main/tests/AppAny.HotChocolate.FluentValidation.Benchmarks
- https://hotchocolategraphql.slack.com/archives/CD9TNKT8T/p1613156440277000
